### PR TITLE
Pinact: Check pending tasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,18 +5,64 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "minimumReleaseAge": "3 days",
+  "schedule": ["before 4am on Monday"],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "assignees": [],
+  "reviewers": [],
+  "semanticCommits": "enabled",
+  "separateMinorPatch": true,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
+      "description": "Security updates - immediate",
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchDatasources": ["npm"],
+      "vulnerabilitySeverity": ["high", "critical"],
+      "minimumReleaseAge": "0 days",
+      "labels": ["security", "dependencies"],
+      "automerge": false
+    },
+    {
+      "description": "GitHub Actions - weekly with longer wait",
       "matchManagers": ["github-actions"],
+      "minimumReleaseAge": "7 days",
+      "schedule": ["before 4am on Monday"]
+    },
+    {
+      "description": "Major updates - bi-weekly with extra wait",
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "14 days",
+      "schedule": ["before 4am on the first day of the month"],
+      "labels": ["major-update", "dependencies"]
+    },
+    {
+      "description": "Minor and patch updates - weekly",
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "groupName": "dependencies (non-major)",
+      "schedule": ["before 4am on Monday"]
+    },
+    {
+      "description": "Playwright - group and test carefully",
+      "matchPackageNames": ["@playwright/test", "playwright"],
+      "groupName": "Playwright",
       "minimumReleaseAge": "7 days"
     },
     {
-      "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "14 days"
+      "description": "Vite and build tools - group together",
+      "matchPackageNames": ["vite", "vitest", "@vitest/ui", "esbuild", "typescript"],
+      "groupName": "Build tooling",
+      "minimumReleaseAge": "5 days"
     },
     {
-      "vulnerabilityAlerts": true,
-      "minimumReleaseAge": "0 days"
+      "description": "Cloudflare packages",
+      "matchPackagePatterns": ["^@cloudflare/", "^wrangler$"],
+      "groupName": "Cloudflare",
+      "minimumReleaseAge": "5 days"
     }
   ]
 }


### PR DESCRIPTION
- Remove invalid vulnerabilityAlerts rule
- Add comprehensive Renovate settings:
  - Schedule: Monday mornings at 4am (Asia/Tokyo)
  - Group related packages (Playwright, Vite/build tools, Cloudflare)
  - Configure minimum release ages for stability
  - Security updates: immediate (0 days)
  - Minor/patch: 3 days wait
  - Major: 14 days wait (monthly)
  - GitHub Actions: 7 days wait
- Enable semantic commits and proper labeling

Renovate will handle all dependency updates without Dependabot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の更新ポリシーを強化しました。スケジュール設定、グループ分けルール、および特定のツール向けのカスタマイズされた更新戦略を導入し、依存関係管理の効率性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->