### PR TITLE
fix(ci): use branch-name for preview worker template

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Prepare Preview Deploy
         id: prepare
-        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@185b45ca868f70d3dcffdb0960f945fe4c27b1bf # v1.1.0
+        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@v1.2.0
         with:
           worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,7 +38,7 @@ jobs:
         id: prepare
         uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@185b45ca868f70d3dcffdb0960f945fe4c27b1bf # v1.1.0
         with:
-          worker-name: '2048-game-pr-${{ github.event.pull_request.number }}'
+          worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'
           environment: 'preview'
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Prepare Preview Deploy
         id: prepare
-        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@v1.2.0
+        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@58f194ae27e8d975621f69fc6ed4c2cf63bf49f7 # v1.2.0
         with:
           worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'


### PR DESCRIPTION
## Summary
- Update preview.yml worker-name from `2048-game-pr-{pr-number}` to `2048-game-{branch-name}`
- Aligns with cf-workers-actions #29 template variable changes

## Test plan
- [ ] Preview deploy workflow passes on this PR
- [ ] Merge after cf-workers-actions release (or pin to new tag)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

このPRは、プレビューデプロイワークフローのワーカー名テンプレートを `2048-game-pr-{PR番号}` から `2048-game-{branch-name}` に変更します。`cf-workers-actions` の #29 に対応するテンプレート変数仕様の変更に合わせた修正です。

- `worker-name` の値を GitHub Actions 式 (`${{ github.event.pull_request.number }}`) から `cf-workers-actions` 側で処理するテンプレート構文 `{branch-name}` に変更。
- ただし、アクションのSHA (`185b45ca868f70d3dcffdb0960f945fe4c27b1bf`) は更新されておらず、PR説明には「cf-workers-actions リリース後にマージ」と明記されており、対応バージョンへの更新が必要。

<h3>Confidence Score: 3/5</h3>

依存する `cf-workers-actions` の新バージョンがまだリリースされていない状態でマージされると、ワーカー名が文字通り `2048-game-{branch-name}` となりデプロイが壊れる可能性があります。

アクションのSHAが `{branch-name}` テンプレート置換をサポートするバージョンに更新されていないため、現時点でマージするとプレビューデプロイが意図通りに動作しない恐れがあります。PR説明自体が「cf-workers-actions のリリース後にマージ」を前提条件としており、その前提が満たされていない状態での変更です。

`.github/workflows/preview.yml` — アクションのSHAを `{branch-name}` 置換に対応した新バージョンに更新する必要があります。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/preview.yml | `worker-name` を `${{ github.event.pull_request.number }}` から `{branch-name}` テンプレート構文に変更。ただし依存する `cf-workers-actions` のSHAが未更新のため、対応バージョンへの更新が必要。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant GHA as GitHub Actions
    participant CFAction as cf-workers-actions prepare-preview-deploy
    participant CF as Cloudflare Workers

    PR->>GHA: PR opened or synchronized
    GHA->>CFAction: "worker-name is 2048-game-{branch-name}"
    Note over CFAction: Replaces {branch-name} with actual branch name (new version required)
    CFAction-->>GHA: deployment-url and deployment-name outputs
    GHA->>CF: wrangler deploy --env preview
    CF-->>GHA: Deploy success
    GHA->>PR: PR Comment with deployment URL
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/preview.yml:39-43
**アクションバージョンが `{branch-name}` に未対応の可能性**

アクションは引き続き `185b45ca868f70d3dcffdb0960f945fe4c27b1bf` (`# v1.1.0`) に固定されており、PR説明の「Merge after cf-workers-actions release (or pin to new tag)」という記述から、`{branch-name}` テンプレート置換をサポートするバージョンがまだリリースされていない可能性があります。現在のバージョンがこの構文を処理しない場合、ワーカー名は文字通り `2048-game-{branch-name}` となり、デプロイが失敗するかまたは意図しない名前のワーカーが作成されます。このPRをマージする前に、アクションのSHAを `{branch-name}` 置換をサポートする新しいリリースに更新してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use branch-name for preview wor..."](https://github.com/harunonsystem/2048-game/commit/3b15fea645c7c228b6718f6634a336214e22707b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35842200)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # コードレビュールール

What: 全てのレスポンスを日本語で記述し、コードの保守性・最適化・セ... ([source](https://app.greptile.com/harunonsystem/-/custom-context?memory=936d2bcf-b73f-4959-b207-05fd396f6bdb))

<!-- /greptile_comment -->