### PR TITLE
chore(ci): pin prepare-preview-deploy to v1.2.2

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Prepare Preview Deploy
         id: prepare
-        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@58f194ae27e8d975621f69fc6ed4c2cf63bf49f7 # v1.2.0
+        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@79e0f2e24b45c2b72d0a4fac98d34e9e6c43bef4 # v1.2.2
         with:
           worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'


### PR DESCRIPTION
Updates prepare-preview-deploy action pin from v1.2.0 to v1.2.2 to include the lowercase worker name normalization (Cloudflare `name` validation fix).

v1.2.2 = v1.2.1 source + rebuilt dist (lowercase logic included in the published action bundle).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

このPRは、`.github/workflows/preview.yml` 内の `prepare-preview-deploy` アクションのピン留めコミットSHAを `v1.2.0`（`58f194ae`）から `v1.2.2`（`79e0f2e2`）へ更新します。v1.2.2にはCloudflare Workers の `name` バリデーション要件に対応するためのワーカー名の小文字正規化ロジックが含まれています。

- `.github/workflows/preview.yml` の1行変更のみで、アクション参照のSHAピンとバージョンコメントを `v1.2.0` から `v1.2.2` に更新しています。
- 他のアクション（`actions/checkout`、`cloudflare/wrangler-action`、`pr-comment`）はSHAピン済みで変更なし。変更範囲は最小限です。

<h3>Confidence Score: 5/5</h3>

1行のSHA更新のみで、ロジック変更はなく安全にマージできます。

変更はワークフロー内の1行（アクションのSHAピンとバージョンコメント）のみです。他のアクションや設定への影響はなく、Cloudflare Workersのワーカー名バリデーション問題に対応した既存の小文字正規化ロジックを取り込む意図は明確です。

特に注意が必要なファイルはありません。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/preview.yml | `prepare-preview-deploy` アクションのSHAピンをv1.2.0からv1.2.2へ1行更新。バージョンコメントも正確に更新済み。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant PPD as prepare-preview-deploy@v1.2.2
    participant CF as Cloudflare Workers
    participant PR as Pull Request

    GH->>PPD: "worker-name: '2048-game-{branch-name}'"
    Note over PPD: ブランチ名を小文字に正規化（v1.2.2の変更点）
    PPD-->>GH: deployment-url, deployment-name
    GH->>CF: wrangler deploy --env preview
    CF-->>GH: デプロイ結果
    GH->>PR: デプロイURLをコメント投稿
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin prepare-preview-deploy to..."](https://github.com/harunonsystem/2048-game/commit/71375e9fff2860e4bd66f21c311f588c0d3ea79e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35999896)</sub>

<!-- /greptile_comment -->