### PR TITLE
chore: update cf-workers-actions to v1.3.1

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Prepare Preview Deploy
         id: prepare
-        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
+        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@454cec0c3ee18e6b6ddb9312364b195962638089 # v1.3.1
         with:
           worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'
@@ -51,7 +51,7 @@ jobs:
           command: deploy --env preview
 
       - name: Comment PR
-        uses: harunonsystem/cf-workers-actions/pr-comment@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
+        uses: harunonsystem/cf-workers-actions/pr-comment@454cec0c3ee18e6b6ddb9312364b195962638089 # v1.3.1
         with:
           deployment-url: ${{ steps.prepare.outputs.deployment-url }}
           deployment-success: ${{ steps.deploy.outcome == 'success' }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Prepare Preview Deploy
         id: prepare
-        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@79e0f2e24b45c2b72d0a4fac98d34e9e6c43bef4 # v1.2.2
+        uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
         with:
           worker-name: '2048-game-{branch-name}'
           domain: 'harunonsystem.workers.dev'
@@ -51,7 +51,7 @@ jobs:
           command: deploy --env preview
 
       - name: Comment PR
-        uses: harunonsystem/cf-workers-actions/pr-comment@79e0f2e24b45c2b72d0a4fac98d34e9e6c43bef4 # v1.2.2
+        uses: harunonsystem/cf-workers-actions/pr-comment@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
         with:
           deployment-url: ${{ steps.prepare.outputs.deployment-url }}
           deployment-success: ${{ steps.deploy.outcome == 'success' }}

--- a/.github/workflows/workers-delete.yml
+++ b/.github/workflows/workers-delete.yml
@@ -30,7 +30,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Cleanup PR Worker
-        uses: harunonsystem/cf-workers-actions/cleanup@79e0f2e24b45c2b72d0a4fac98d34e9e6c43bef4 # v1.2.2
+        uses: harunonsystem/cf-workers-actions/cleanup@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
         with:
           worker-names: '2048-game-pr-${{ github.event.pull_request.number }}'
           cloudflare-api-token: ${{ steps.load-secrets.outputs.CLOUDFLARE_API_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Cleanup Workers
-        uses: harunonsystem/cf-workers-actions/cleanup@79e0f2e24b45c2b72d0a4fac98d34e9e6c43bef4 # v1.2.2
+        uses: harunonsystem/cf-workers-actions/cleanup@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
         with:
           worker-prefix: ${{ github.event.inputs.worker_prefix }}
           worker-numbers: ${{ github.event.inputs.worker_numbers }}

--- a/.github/workflows/workers-delete.yml
+++ b/.github/workflows/workers-delete.yml
@@ -30,7 +30,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Cleanup PR Worker
-        uses: harunonsystem/cf-workers-actions/cleanup@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
+        uses: harunonsystem/cf-workers-actions/cleanup@454cec0c3ee18e6b6ddb9312364b195962638089 # v1.3.1
         with:
           worker-names: '2048-game-pr-${{ github.event.pull_request.number }}'
           cloudflare-api-token: ${{ steps.load-secrets.outputs.CLOUDFLARE_API_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Cleanup Workers
-        uses: harunonsystem/cf-workers-actions/cleanup@cf59a4f742045ec96dc81b645b10310d0cf310e1 # v1.3.0
+        uses: harunonsystem/cf-workers-actions/cleanup@454cec0c3ee18e6b6ddb9312364b195962638089 # v1.3.1
         with:
           worker-prefix: ${{ github.event.inputs.worker_prefix }}
           worker-numbers: ${{ github.event.inputs.worker_numbers }}


### PR DESCRIPTION
## Summary

cf-workers-actions の pin を v1.3.1（454cec0）に更新。

## Changes

- 既に存在しない worker の削除が ❌ Failed ではなく skip 扱いになる（`This Worker does not exist on your account.` の 404 を status ベースで判定するようになった）
- action runtime が node20 → node24 になり、GitHub Actions の Node.js 20 deprecation 警告が消える
- v1.3.1 の bundle は undici が patched（6.27）になっていて、上流の Dependabot alert も解消済み

## Test plan

- [ ] workers-delete workflow が warning なしで完走すること（マージ後の次回 PR close 時に確認）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プレビュー環境へのデプロイワークフローで使用する処理を更新しました。  
  * プルリクエスト終了後のクリーンアップワークフローで使用する処理を更新しました。  
  * 既存の設定や処理内容、入出力は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->