### PR TITLE
fix: use PR number for preview Worker names

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: refs/pull/${{ inputs.pull_request_number || github.event.pull_request.number }}/merge
 
       - name: Setup Node.js and Dependencies
         uses: ./.github/actions/setup-node-deps

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,12 +4,18 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'Pull request number to deploy manually'
+        required: true
+        type: number
 
 jobs:
   test-and-deploy:
     runs-on: ubuntu-latest
     # PRがオープン状態の場合のみ実行（マージ後のrebaseによる再デプロイを防止）
-    if: github.event.pull_request.state == 'open'
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.state == 'open'
     permissions:
       contents: read
       actions: read
@@ -38,7 +44,7 @@ jobs:
         id: prepare
         uses: harunonsystem/cf-workers-actions/prepare-preview-deploy@454cec0c3ee18e6b6ddb9312364b195962638089 # v1.3.1
         with:
-          worker-name: '2048-game-{branch-name}'
+          worker-name: '2048-game-pr-${{ github.event.pull_request.number || inputs.pull_request_number }}'
           domain: 'harunonsystem.workers.dev'
           environment: 'preview'
 


### PR DESCRIPTION
## Summary

- Use the PR number for preview Cloudflare Worker names instead of the branch name.
- Add manual workflow dispatch support with a PR number input.
- Keep preview Worker names aligned with the closed-PR cleanup workflow.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プルリクエストのプレビューを、手動実行でも作成できるようになりました。
  * 手動実行時にプルリクエスト番号を指定して対象を切り替え可能です。
  * プレビュー名（およびプレビュー生成に関わる識別情報）が、ブランチ名ではなくプルリクエスト番号に基づいて決まるようになりました。
  * 自動実行・手動実行の双方で、プレビュー対象が適切に切り替わるよう調整されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->